### PR TITLE
this branch is 1 step behind main, ill make another one

### DIFF
--- a/lua/postprocess/scaf.lua
+++ b/lua/postprocess/scaf.lua
@@ -13,6 +13,12 @@ local pp_scaf_greeny = CreateClientConVar( "pp_scaf_greeny", "2", true, false, "
 local pp_scaf_bluex = CreateClientConVar( "pp_scaf_bluex", "0", true, false, "Mixing of chromatic aberrations in the blue channel along the X-axis. <Default 0>", 0, 100 )
 local pp_scaf_bluey = CreateClientConVar( "pp_scaf_bluey", "0", true, false, "Mixing of chromatic aberrations in the blue channel along the Y-axis. <Default 0>", 0, 100 )
 
+-- brightness settings
+local pp_scaf_autoexposure_min = CreateClientConVar ( "pp_scaf_autoexposure_min", "0", true, false, "Sets HDR Auto Exposure Minimum. <Default 0>", 0, 10 )
+local pp_scaf_autoexposure_max = CreateClientConVar ( "pp_scaf_autoexposure_max", "1", true, false, "Sets HDR Auto Exposure Maximum. <Default 2>", 0, 10 )
+local pp_scaf_bloom_scalefactor = CreateClientConVar ( "pp_scaf_bloom_scalefactor", "0.2", true, false, "Sets Bloom Scalefactor Scalar. <Default 1>", 0, 1 )
+local pp_scaf_bloomscale = CreateClientConVar ( "pp_scaf_bloomscale", "0", true, false, "Sets Bloom Scale. <Default 1>", 0, 1 )
+
 list.Set( "PostProcess", "#pp_scaf.name", {
 	["icon"] = "gui/postprocess/scaf.jpg",
 	["convar"] = pp_scaf:GetName(),
@@ -31,6 +37,13 @@ list.Set( "PostProcess", "#pp_scaf.name", {
 					[ pp_scaf_greeny:GetName() ] = pp_scaf_greeny:GetDefault(),
 					[ pp_scaf_bluey:GetName() ] = pp_scaf_bluey:GetDefault(),
 					[ pp_scaf_bluex:GetName() ] = pp_scaf_bluex:GetDefault()
+							
+					-- brightness settings
+					[ pp_scaf_autoexposure_min:GetName() ] = pp_scaf_autoexposure_min:GetDefault(),
+					[ pp_scaf_autoexposure_max:GetName() ] = pp_scaf_autoexposure_max:GetDefault(),
+					[ pp_scaf_bloom_scalefactor:GetName() ] = pp_scaf_bloom_scalefactor:GetDefault(),
+					[ pp_scaf_bloomscale:GetName() ] = pp_scaf_bloomscale:GetDefault()
+	
 				}
 			},
 			["CVars"] = {
@@ -117,6 +130,44 @@ list.Set( "PostProcess", "#pp_scaf.name", {
 			["Type"] = "Float",
 			["Help"] = true
 		} )
+
+		-- brightness settings
+		panel:AddControl( "Slider", {
+			["Label"] = "#pp_scaf.autoexposure_min",
+			["Command"] = pp_scaf_autoexposure_min:GetName(),
+			["Min"] = tostring( pp_scaf_autoexposure_min:GetMin() ),
+			["Max"] = tostring( pp_scaf_autoexposure_min:GetMax() ),
+			["Type"] = "Float",
+			["Help"] = true
+		} )
+		
+		panel:AddControl( "Slider", {
+			["Label"] = "#pp_scaf.autoexposure_max",
+			["Command"] = pp_scaf_autoexposure_max:GetName(),
+			["Min"] = tostring( pp_scaf_autoexposure_max:GetMin() ),
+			["Max"] = tostring( pp_scaf_autoexposure_max:GetMax() ),
+			["Type"] = "Float",
+			["Help"] = true
+		} )
+		
+		panel:AddControl( "Slider", {
+			["Label"] = "#pp_scaf.bloom_scalefactor",
+			["Command"] = pp_scaf_bloom_scalefactor:GetName(),
+			["Min"] = tostring( pp_scaf_bloom_scalefactor:GetMin() ),
+			["Max"] = tostring( pp_scaf_bloom_scalefactor:GetMax() ),
+			["Type"] = "Float",
+			["Help"] = true
+		} )
+		
+		panel:AddControl( "Slider", {
+			["Label"] = "#pp_scaf.bloomscale",
+			["Command"] = pp_scaf_bloomscale:GetName(),
+			["Min"] = tostring( pp_scaf_bloomscale:GetMin() ),
+			["Max"] = tostring( pp_scaf_bloomscale:GetMax() ),
+			["Type"] = "Float",
+			["Help"] = true
+		} )
+			
 	end
 } )
 
@@ -176,4 +227,22 @@ hook.Add( "RenderScreenspaceEffects", addonName, function()
 
 	SetMaterial( blue )
 	DrawScreenQuadEx( -blueX / 2, -blueY / 2, width + blueX, height + blueY )
+
+	-- brightness settings
+	RunConsoleCommand("mat_autoexposure_min", pp_scaf_autoexposure_min:GetFloat());
+	RunConsoleCommand("mat_autoexposure_max", pp_scaf_autoexposure_max:GetFloat());
+	RunConsoleCommand("mat_bloom_scalefactor_scalar", pp_scaf_bloom_scalefactor:GetFloat());
+	RunConsoleCommand("mat_bloomscale", pp_scaf_bloomscale:GetFloat());
+		
 end )
+
+-----------------------------------------------------------------------------------------------
+-- at this point i dont know how to
+-- revert brighness settings to default GMOD value when pp_scaf checkbox unselected
+if not enabled then
+	RunConsoleCommand("mat_autoexposure_min", "0");
+	RunConsoleCommand("mat_autoexposure_max", "2");
+	RunConsoleCommand("mat_bloom_scalefactor_scalar", "1");
+	RunConsoleCommand("mat_bloomscale", "1");
+end
+------------------------------------------------------------------------------------------------

--- a/resource/localization/en/pp_scaf.properties
+++ b/resource/localization/en/pp_scaf.properties
@@ -21,3 +21,15 @@ pp_scaf.bluex.help=Mixing of chromatic aberrations in the blue channel along the
 
 pp_scaf.bluey=Blue offset by Y
 pp_scaf.bluey.help=Mixing of chromatic aberrations in the blue channel along the Y-axis. <Default 0>
+
+pp_scaf.autoexposure_min=mat_autoexposure_min
+pp_scaf.autoexposure_min.help=Sets HDR Auto Exposure Minimum. <Default 0>
+
+pp_scaf.autoexposure_max=mat_autoexposure_max
+pp_scaf.autoexposure_max.help=Sets HDR Auto Exposure Maximum. <Default 2>
+
+pp_scaf.bloom_scalefactor=mat_bloom_scalefactor_scalar
+pp_scaf.bloom_scalefactor.help=Sets Bloom Scalefactor Scalar. <Default 1>
+
+pp_scaf.bloomscale=mat_bloomscale
+pp_scaf.bloomscale.help=Sets Bloom Scale. <Default 1>

--- a/resource/localization/ru/pp_scaf.properties
+++ b/resource/localization/ru/pp_scaf.properties
@@ -21,3 +21,16 @@ pp_scaf.bluex.help=Смешение хроматических аберраци�
 
 pp_scaf.bluey=Смещение синего по Y
 pp_scaf.bluey.help=Смешение хроматических аберраций в синем канале вдоль оси Y. <По умолчанию 0>
+
+// im sorry if the translation is wrong, im using google translate
+pp_scaf.autoexposure_min=mat_autoexposure_min
+pp_scaf.autoexposure_min.help=Устанавливает минимальную автоматическую экспозицию HDR. <По умолчанию 0>
+
+pp_scaf.autoexposure_max=mat_autoexposure_max
+pp_scaf.autoexposure_max.help=Устанавливает максимальную автоматическую экспозицию HDR. <По умолчанию 2>
+
+pp_scaf.bloom_scalefactor=mat_bloom_scalefactor_scalar
+pp_scaf.bloom_scalefactor.help=Устанавливает скаляр масштабного коэффициента Блума. <По умолчанию 1>
+
+pp_scaf.bloomscale=mat_bloomscale
+pp_scaf.bloomscale.help=Устанавливает шкалу цветения. <По умолчанию 1>


### PR DESCRIPTION
### **The issue:**
when enabling the effect, it will slightly changing brightness of the image.
it will more noticable on darker maps.

### **Why:**
maybe because additional 4 layer of color
RGB and Black
if i only use the RGB w/o Black, it will be flashbang bright, therefore the color black is required.

### **my Solution:**
Adding some settings, so user can adjust depending on the map.

Console Command:
```
mat_autoexposure_min
mat_autoexposure_max
mat_bloom_scalefactor_scalar
mat_bloomscale
```

user can setting these comands directly for easy access, also saves the preset.
when user disable/uncheckbox the effect these commands will revert to original gmod value.

my default value vs gmod:
```
mat_autoexposure_min           0    | 0
mat_autoexposure_max           1.25 | 2
mat_bloom_scalefactor_scalar   0.2  | 1
mat_bloomscale                 0    | 1
```