### PR TITLE
Fixing brightness issue

### DIFF
--- a/lua/postprocess/scaf.lua
+++ b/lua/postprocess/scaf.lua
@@ -14,11 +14,11 @@ local pp_scaf_greeny = CreateClientConVar( "pp_scaf_greeny", "2", true, false, "
 local pp_scaf_bluex = CreateClientConVar( "pp_scaf_bluex", "0", true, false, "Mixing of chromatic aberrations in the blue channel along the X-axis.", 0, 128 )
 local pp_scaf_bluey = CreateClientConVar( "pp_scaf_bluey", "0", true, false, "Mixing of chromatic aberrations in the blue channel along the Y-axis.", 0, 128 )
 
--- brightness options
-local pp_scaf_autoexposure_min = CreateClientConVar ( "pp_scaf_autoexposure_min", "0", true, false, "Sets HDR Auto Exposure Minimum. <Default 0>", 0, 10 )
-local pp_scaf_autoexposure_max = CreateClientConVar ( "pp_scaf_autoexposure_max", "1.25", true, false, "Sets HDR Auto Exposure Maximum. <Default 2>", 0, 10 )
-local pp_scaf_bloom_scalefactor = CreateClientConVar ( "pp_scaf_bloom_scalefactor", "0.2", true, false, "Sets Bloom Scalefactor Scalar. <Default 1>", 0, 1 )
-local pp_scaf_bloomscale = CreateClientConVar ( "pp_scaf_bloomscale", "0", true, false, "Sets Bloom Scale. <Default 1>", 0, 1 )
+-- Brightness options
+local mat_autoexposure_min = GetConVar( "mat_autoexposure_min" )
+local mat_autoexposure_max = GetConVar( "mat_autoexposure_max" )
+local mat_bloom_scalefactor_scalar = GetConVar( "mat_bloom_scalefactor_scalar" )
+local mat_bloomscale = GetConVar( "mat_bloomscale" )
 
 list.Set( "PostProcess", "#pp_scaf.name", {
 	["icon"] = "gui/postprocess/scaf.jpg",
@@ -36,13 +36,12 @@ list.Set( "PostProcess", "#pp_scaf.name", {
 					[ pp_scaf_redy:GetName() ] = pp_scaf_redy:GetDefault(),
 					[ pp_scaf_greenx:GetName() ] = pp_scaf_greenx:GetDefault(),
 					[ pp_scaf_greeny:GetName() ] = pp_scaf_greeny:GetDefault(),
-					[ pp_scaf_bluey:GetName() ] = pp_scaf_bluey:GetDefault(),
 					[ pp_scaf_bluex:GetName() ] = pp_scaf_bluex:GetDefault(),
-					
-					[ pp_scaf_autoexposure_min:GetName() ] = pp_scaf_autoexposure_min:GetDefault(),
-					[ pp_scaf_autoexposure_max:GetName() ] = pp_scaf_autoexposure_max:GetDefault(),
-					[ pp_scaf_bloom_scalefactor:GetName() ] = pp_scaf_bloom_scalefactor:GetDefault(),
-					[ pp_scaf_bloomscale:GetName() ] = pp_scaf_bloomscale:GetDefault()
+					[ pp_scaf_bluey:GetName() ] = pp_scaf_bluey:GetDefault(),
+					[ mat_autoexposure_min:GetName() ] = mat_autoexposure_min:GetDefault(),
+					[ mat_autoexposure_max:GetName() ] = mat_autoexposure_max:GetDefault(),
+					[ mat_bloom_scalefactor_scalar:GetName() ] = mat_bloom_scalefactor_scalar:GetDefault(),
+					[ mat_bloomscale:GetName() ] = mat_bloomscale:GetDefault()
 				}
 			},
 			["CVars"] = {
@@ -54,11 +53,10 @@ list.Set( "PostProcess", "#pp_scaf.name", {
 				pp_scaf_greeny:GetName(),
 				pp_scaf_bluey:GetName(),
 				pp_scaf_bluex:GetName(),
-				
-				pp_scaf_autoexposure_min:GetName(),
-				pp_scaf_autoexposure_max:GetName(),
-				pp_scaf_bloom_scalefactor:GetName(),
-				pp_scaf_bloomscale:GetName()
+				mat_autoexposure_min:GetName(),
+				mat_autoexposure_max:GetName(),
+				mat_bloom_scalefactor_scalar:GetName(),
+				mat_bloomscale:GetName()
 			}
 		} )
 
@@ -135,39 +133,39 @@ list.Set( "PostProcess", "#pp_scaf.name", {
 			["Help"] = true
 		} )
 			
-		-- brightness options
+		-- Brightness options
 		panel:AddControl( "Slider", {
 			["Label"] = "#pp_scaf.autoexposure_min",
-			["Command"] = pp_scaf_autoexposure_min:GetName(),
-			["Min"] = tostring( pp_scaf_autoexposure_min:GetMin() ),
-			["Max"] = tostring( pp_scaf_autoexposure_min:GetMax() ),
+			["Command"] = mat_autoexposure_min:GetName(),
+			["Min"] = tostring( mat_autoexposure_min:GetMin() ),
+			["Max"] = tostring( mat_autoexposure_min:GetMax() ),
 			["Type"] = "Float",
 			["Help"] = true
 		} )
 		
 		panel:AddControl( "Slider", {
 			["Label"] = "#pp_scaf.autoexposure_max",
-			["Command"] = pp_scaf_autoexposure_max:GetName(),
-			["Min"] = tostring( pp_scaf_autoexposure_max:GetMin() ),
-			["Max"] = tostring( pp_scaf_autoexposure_max:GetMax() ),
+			["Command"] = mat_autoexposure_max:GetName(),
+			["Min"] = tostring( mat_autoexposure_max:GetMin() ),
+			["Max"] = tostring( mat_autoexposure_max:GetMax() ),
 			["Type"] = "Float",
 			["Help"] = true
 		} )
 		
 		panel:AddControl( "Slider", {
 			["Label"] = "#pp_scaf.bloom_scalefactor",
-			["Command"] = pp_scaf_bloom_scalefactor:GetName(),
-			["Min"] = tostring( pp_scaf_bloom_scalefactor:GetMin() ),
-			["Max"] = tostring( pp_scaf_bloom_scalefactor:GetMax() ),
+			["Command"] = mat_bloom_scalefactor_scalar:GetName(),
+			["Min"] = tostring( mat_bloom_scalefactor_scalar:GetMin() ),
+			["Max"] = tostring( mat_bloom_scalefactor_scalar:GetMax() ),
 			["Type"] = "Float",
 			["Help"] = true
 		} )
 		
 		panel:AddControl( "Slider", {
 			["Label"] = "#pp_scaf.bloomscale",
-			["Command"] = pp_scaf_bloomscale:GetName(),
-			["Min"] = tostring( pp_scaf_bloomscale:GetMin() ),
-			["Max"] = tostring( pp_scaf_bloomscale:GetMax() ),
+			["Command"] = mat_bloomscale:GetName(),
+			["Min"] = tostring( mat_bloomscale:GetMin() ),
+			["Max"] = tostring( mat_bloomscale:GetMax() ),
 			["Type"] = "Float",
 			["Help"] = true	
 		} )
@@ -233,16 +231,5 @@ hook.Add( "RenderScreenspaceEffects", addonName, function()
 
 		SetMaterial( blue )
 		DrawScreenQuadEx( -blueX / 2, -blueY / 2, width + blueX, height + blueY )
-		
-		RunConsoleCommand("mat_autoexposure_min", pp_scaf_autoexposure_min:GetFloat());
-		RunConsoleCommand("mat_autoexposure_max", pp_scaf_autoexposure_max:GetFloat());
-		RunConsoleCommand("mat_bloom_scalefactor_scalar", pp_scaf_bloom_scalefactor:GetFloat());
-		RunConsoleCommand("mat_bloomscale", pp_scaf_bloomscale:GetFloat());
-		
-		else
-		RunConsoleCommand("mat_autoexposure_min", "0");
-	    	RunConsoleCommand("mat_autoexposure_max", "2");
-	   	RunConsoleCommand("mat_bloom_scalefactor_scalar", "1");
-	  	RunConsoleCommand("mat_bloomscale", "1");
 	end
 end )

--- a/lua/postprocess/scaf.lua
+++ b/lua/postprocess/scaf.lua
@@ -137,8 +137,8 @@ list.Set( "PostProcess", "#pp_scaf.name", {
 		panel:AddControl( "Slider", {
 			["Label"] = "#pp_scaf.autoexposure_min",
 			["Command"] = mat_autoexposure_min:GetName(),
-			["Min"] = tostring( mat_autoexposure_min:GetMin() ),
-			["Max"] = tostring( mat_autoexposure_min:GetMax() ),
+			["Min"] = tostring( 0 ),
+			["Max"] = tostring( 10 ),
 			["Type"] = "Float",
 			["Help"] = true
 		} )
@@ -146,8 +146,8 @@ list.Set( "PostProcess", "#pp_scaf.name", {
 		panel:AddControl( "Slider", {
 			["Label"] = "#pp_scaf.autoexposure_max",
 			["Command"] = mat_autoexposure_max:GetName(),
-			["Min"] = tostring( mat_autoexposure_max:GetMin() ),
-			["Max"] = tostring( mat_autoexposure_max:GetMax() ),
+			["Min"] = tostring( 0 ),
+			["Max"] = tostring( 10 ),
 			["Type"] = "Float",
 			["Help"] = true
 		} )
@@ -155,8 +155,8 @@ list.Set( "PostProcess", "#pp_scaf.name", {
 		panel:AddControl( "Slider", {
 			["Label"] = "#pp_scaf.bloom_scalefactor",
 			["Command"] = mat_bloom_scalefactor_scalar:GetName(),
-			["Min"] = tostring( mat_bloom_scalefactor_scalar:GetMin() ),
-			["Max"] = tostring( mat_bloom_scalefactor_scalar:GetMax() ),
+			["Min"] = tostring( 0 ),
+			["Max"] = tostring( 1 ),
 			["Type"] = "Float",
 			["Help"] = true
 		} )
@@ -164,8 +164,8 @@ list.Set( "PostProcess", "#pp_scaf.name", {
 		panel:AddControl( "Slider", {
 			["Label"] = "#pp_scaf.bloomscale",
 			["Command"] = mat_bloomscale:GetName(),
-			["Min"] = tostring( mat_bloomscale:GetMin() ),
-			["Max"] = tostring( mat_bloomscale:GetMax() ),
+			["Min"] = tostring( 0 ),
+			["Max"] = tostring( 1 ),
 			["Type"] = "Float",
 			["Help"] = true	
 		} )

--- a/lua/postprocess/scaf.lua
+++ b/lua/postprocess/scaf.lua
@@ -14,6 +14,12 @@ local pp_scaf_greeny = CreateClientConVar( "pp_scaf_greeny", "2", true, false, "
 local pp_scaf_bluex = CreateClientConVar( "pp_scaf_bluex", "0", true, false, "Mixing of chromatic aberrations in the blue channel along the X-axis.", 0, 128 )
 local pp_scaf_bluey = CreateClientConVar( "pp_scaf_bluey", "0", true, false, "Mixing of chromatic aberrations in the blue channel along the Y-axis.", 0, 128 )
 
+-- brightness options
+local pp_scaf_autoexposure_min = CreateClientConVar ( "pp_scaf_autoexposure_min", "0", true, false, "Sets HDR Auto Exposure Minimum. <Default 0>", 0, 10 )
+local pp_scaf_autoexposure_max = CreateClientConVar ( "pp_scaf_autoexposure_max", "1.25", true, false, "Sets HDR Auto Exposure Maximum. <Default 2>", 0, 10 )
+local pp_scaf_bloom_scalefactor = CreateClientConVar ( "pp_scaf_bloom_scalefactor", "0.2", true, false, "Sets Bloom Scalefactor Scalar. <Default 1>", 0, 1 )
+local pp_scaf_bloomscale = CreateClientConVar ( "pp_scaf_bloomscale", "0", true, false, "Sets Bloom Scale. <Default 1>", 0, 1 )
+
 list.Set( "PostProcess", "#pp_scaf.name", {
 	["icon"] = "gui/postprocess/scaf.jpg",
 	["convar"] = pp_scaf:GetName(),
@@ -31,7 +37,12 @@ list.Set( "PostProcess", "#pp_scaf.name", {
 					[ pp_scaf_greenx:GetName() ] = pp_scaf_greenx:GetDefault(),
 					[ pp_scaf_greeny:GetName() ] = pp_scaf_greeny:GetDefault(),
 					[ pp_scaf_bluey:GetName() ] = pp_scaf_bluey:GetDefault(),
-					[ pp_scaf_bluex:GetName() ] = pp_scaf_bluex:GetDefault()
+					[ pp_scaf_bluex:GetName() ] = pp_scaf_bluex:GetDefault(),
+					
+					[ pp_scaf_autoexposure_min:GetName() ] = pp_scaf_autoexposure_min:GetDefault(),
+					[ pp_scaf_autoexposure_max:GetName() ] = pp_scaf_autoexposure_max:GetDefault(),
+					[ pp_scaf_bloom_scalefactor:GetName() ] = pp_scaf_bloom_scalefactor:GetDefault(),
+					[ pp_scaf_bloomscale:GetName() ] = pp_scaf_bloomscale:GetDefault()
 				}
 			},
 			["CVars"] = {
@@ -42,7 +53,12 @@ list.Set( "PostProcess", "#pp_scaf.name", {
 				pp_scaf_greenx:GetName(),
 				pp_scaf_greeny:GetName(),
 				pp_scaf_bluey:GetName(),
-				pp_scaf_bluex:GetName()
+				pp_scaf_bluex:GetName(),
+				
+				pp_scaf_autoexposure_min:GetName(),
+				pp_scaf_autoexposure_max:GetName(),
+				pp_scaf_bloom_scalefactor:GetName(),
+				pp_scaf_bloomscale:GetName()
 			}
 		} )
 
@@ -118,6 +134,43 @@ list.Set( "PostProcess", "#pp_scaf.name", {
 			["Type"] = "Float",
 			["Help"] = true
 		} )
+			
+		-- brightness options
+		panel:AddControl( "Slider", {
+			["Label"] = "#pp_scaf.autoexposure_min",
+			["Command"] = pp_scaf_autoexposure_min:GetName(),
+			["Min"] = tostring( pp_scaf_autoexposure_min:GetMin() ),
+			["Max"] = tostring( pp_scaf_autoexposure_min:GetMax() ),
+			["Type"] = "Float",
+			["Help"] = true
+		} )
+		
+		panel:AddControl( "Slider", {
+			["Label"] = "#pp_scaf.autoexposure_max",
+			["Command"] = pp_scaf_autoexposure_max:GetName(),
+			["Min"] = tostring( pp_scaf_autoexposure_max:GetMin() ),
+			["Max"] = tostring( pp_scaf_autoexposure_max:GetMax() ),
+			["Type"] = "Float",
+			["Help"] = true
+		} )
+		
+		panel:AddControl( "Slider", {
+			["Label"] = "#pp_scaf.bloom_scalefactor",
+			["Command"] = pp_scaf_bloom_scalefactor:GetName(),
+			["Min"] = tostring( pp_scaf_bloom_scalefactor:GetMin() ),
+			["Max"] = tostring( pp_scaf_bloom_scalefactor:GetMax() ),
+			["Type"] = "Float",
+			["Help"] = true
+		} )
+		
+		panel:AddControl( "Slider", {
+			["Label"] = "#pp_scaf.bloomscale",
+			["Command"] = pp_scaf_bloomscale:GetName(),
+			["Min"] = tostring( pp_scaf_bloomscale:GetMin() ),
+			["Max"] = tostring( pp_scaf_bloomscale:GetMax() ),
+			["Type"] = "Float",
+			["Help"] = true	
+		} )
 	end
 } )
 
@@ -180,5 +233,16 @@ hook.Add( "RenderScreenspaceEffects", addonName, function()
 
 		SetMaterial( blue )
 		DrawScreenQuadEx( -blueX / 2, -blueY / 2, width + blueX, height + blueY )
+		
+		RunConsoleCommand("mat_autoexposure_min", pp_scaf_autoexposure_min:GetFloat());
+		RunConsoleCommand("mat_autoexposure_max", pp_scaf_autoexposure_max:GetFloat());
+		RunConsoleCommand("mat_bloom_scalefactor_scalar", pp_scaf_bloom_scalefactor:GetFloat());
+		RunConsoleCommand("mat_bloomscale", pp_scaf_bloomscale:GetFloat());
+		
+		else
+		RunConsoleCommand("mat_autoexposure_min", "0");
+	    	RunConsoleCommand("mat_autoexposure_max", "2");
+	   	RunConsoleCommand("mat_bloom_scalefactor_scalar", "1");
+	  	RunConsoleCommand("mat_bloomscale", "1");
 	end
 end )

--- a/resource/localization/en/pp_scaf.properties
+++ b/resource/localization/en/pp_scaf.properties
@@ -23,7 +23,7 @@ pp_scaf.bluey=Blue offset by Y
 pp_scaf.bluey.help=Mixing of chromatic aberrations in the blue channel along the Y-axis. <Default 0>
 
 pp_scaf.autoexposure_min=mat_autoexposure_min
-pp_scaf.autoexposure_min.help=Sets HDR Auto Exposure Minimum. <Default 0>
+pp_scaf.autoexposure_min.help=Sets HDR Auto Exposure Minimum. <Default 0.5>
 
 pp_scaf.autoexposure_max=mat_autoexposure_max
 pp_scaf.autoexposure_max.help=Sets HDR Auto Exposure Maximum. <Default 2>

--- a/resource/localization/en/pp_scaf.properties
+++ b/resource/localization/en/pp_scaf.properties
@@ -21,3 +21,15 @@ pp_scaf.bluex.help=Mixing of chromatic aberrations in the blue channel along the
 
 pp_scaf.bluey=Blue offset by Y
 pp_scaf.bluey.help=Mixing of chromatic aberrations in the blue channel along the Y-axis. <Default 0>
+
+pp_scaf.autoexposure_min=mat_autoexposure_min
+pp_scaf.autoexposure_min.help=Sets HDR Auto Exposure Minimum. <Default 0>
+
+pp_scaf.autoexposure_max=mat_autoexposure_max
+pp_scaf.autoexposure_max.help=Sets HDR Auto Exposure Maximum. <Default 2>
+
+pp_scaf.bloom_scalefactor=mat_bloom_scalefactor_scalar
+pp_scaf.bloom_scalefactor.help=Sets Bloom Scalefactor Scalar. <Default 1>
+
+pp_scaf.bloomscale=mat_bloomscale
+pp_scaf.bloomscale.help=Sets Bloom Scale. <Default 1>

--- a/resource/localization/ru/pp_scaf.properties
+++ b/resource/localization/ru/pp_scaf.properties
@@ -24,7 +24,7 @@ pp_scaf.bluey.help=Смешение хроматических аберраци�
 
 // im sorry if the translation is wrong, im using google translate
 pp_scaf.autoexposure_min=mat_autoexposure_min
-pp_scaf.autoexposure_min.help=Устанавливает минимальную автоматическую экспозицию HDR. <По умолчанию 0>
+pp_scaf.autoexposure_min.help=Устанавливает минимальную автоматическую экспозицию HDR. <По умолчанию 0.5>
 
 pp_scaf.autoexposure_max=mat_autoexposure_max
 pp_scaf.autoexposure_max.help=Устанавливает максимальную автоматическую экспозицию HDR. <По умолчанию 2>

--- a/resource/localization/ru/pp_scaf.properties
+++ b/resource/localization/ru/pp_scaf.properties
@@ -21,3 +21,16 @@ pp_scaf.bluex.help=Смешение хроматических аберраци�
 
 pp_scaf.bluey=Смещение синего по Y
 pp_scaf.bluey.help=Смешение хроматических аберраций в синем канале вдоль оси Y. <По умолчанию 0>
+
+// im sorry if the translation is wrong, im using google translate
+pp_scaf.autoexposure_min=mat_autoexposure_min
+pp_scaf.autoexposure_min.help=Устанавливает минимальную автоматическую экспозицию HDR. <По умолчанию 0>
+
+pp_scaf.autoexposure_max=mat_autoexposure_max
+pp_scaf.autoexposure_max.help=Устанавливает максимальную автоматическую экспозицию HDR. <По умолчанию 2>
+
+pp_scaf.bloom_scalefactor=mat_bloom_scalefactor_scalar
+pp_scaf.bloom_scalefactor.help=Устанавливает скаляр масштабного коэффициента Блума. <По умолчанию 1>
+
+pp_scaf.bloomscale=mat_bloomscale
+pp_scaf.bloomscale.help=Устанавливает шкалу цветения. <По умолчанию 1>


### PR DESCRIPTION
### **The issue:**
when enabling the effect, it will slightly changing brightness of the image.
it will more noticable on darker maps.

### **Why:**
maybe because additional 4 layer of color
RGB and Black
if i only use the RGB w/o Black, it will be flashbang bright, therefore the color black is required.

### **my Solution:**
Adding some settings, so user can adjust depending on the map.

Console Command:
```
mat_autoexposure_min
mat_autoexposure_max
mat_bloom_scalefactor_scalar
mat_bloomscale
```

user can setting these comands directly for easy access, also saves the preset.
